### PR TITLE
Improve safety and ergonomics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdjson"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Mike Lubinets <lubinetsm@yandex.ru>"]
 description = "TDLIB Json Client for Rust"
 documentation = "https://docs.rs/crate/tdjson"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ license = "MIT"
 keywords = ["telegram", "tdlib", "bindings"]
 
 [dependencies]
-tdjson-sys = "0.1"
+tdjson-sys = "0.1.3"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please follow the steps described in the [tdlib-sys](https://github.com/mersinva
 
 Add `tdjson` to your `Cargo.toml` dependency list
 ```toml
-tdjson = "0.1"
+tdjson = "0.2"
 ```
 
 And let the Cargo do it's magic!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,19 @@ use std::ffi::{
 use std::time::Duration;
 use std::ops::Drop;
 
+pub fn set_log_file(path: &str) -> Result<i32, std::ffi::NulError> {
+    let cpath = CString::new(path)?;
+    unsafe {
+        Ok(td_set_log_file_path(cpath.as_ptr()))
+    }
+}
+
+pub fn set_log_verbosity_level(level : i32) {
+    unsafe {
+        td_set_log_verbosity_level(level);
+    }
+}
+
 pub struct Client {
     client_ptr: *mut c_void
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ impl Client {
         }
     }
 
-    pub fn send(&mut self, request: &str) {
+    pub fn send(&self, request: &str) {
         let crequest = CString::new(request).expect("null character in request string");
         unsafe {
             td_json_client_send(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ use std::ffi::{
     CStr,
 };
 
-use std::str::Utf8Error;
 use std::time::Duration;
 use std::ops::Drop;
 
@@ -42,7 +41,7 @@ impl Client {
         }
     }
 
-    pub fn execute<'a>(&'a mut self, request: &str) -> Result<Option<&'a str>, Utf8Error> {
+    pub fn execute<'a>(&'a mut self, request: &str) -> Option<&'a str> {
         let crequest = CString::new(request).expect("null character in request string");
         unsafe {
             let answer = td_json_client_execute(
@@ -52,10 +51,10 @@ impl Client {
 
             let answer = answer as *const c_char;
             if answer == std::ptr::null() {
-                return Ok(None);
+                return None;
             }
             let answer = CStr::from_ptr(answer);
-            answer.to_str().map(|s| Some(s))
+            Some(answer.to_str().expect("tdlib sent invalid utf-8 string"))
         }
     }
 
@@ -69,7 +68,7 @@ impl Client {
         }
     }
 
-    pub fn receive<'a>(&'a mut self, timeout: Duration) -> Result<Option<&'a str>, Utf8Error> {
+    pub fn receive<'a>(&'a mut self, timeout: Duration) -> Option<&'a str> {
         let timeout = timeout.as_secs() as f64;
 
         unsafe {
@@ -80,11 +79,11 @@ impl Client {
 
             let answer = answer as *const c_char;
             if answer == std::ptr::null() {
-                return Ok(None);
+                return None;
             }
             let answer = CStr::from_ptr(answer);
 
-            answer.to_str().map(|s| Some(s))
+            Some(answer.to_str().expect("tdlib sent invalid utf-8 string"))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,13 +150,6 @@ unsafe impl Send for SendClient{}
 unsafe impl Sync for SendClient{}
 
 impl SendClient {
-    pub fn execute<'a>(&'a mut self, request: &str) -> Option<&'a str> {
-        // SAFE because we are taking self by mutable referene
-        unsafe {
-            self.inner.execute(request)
-        }
-    }
-
     pub fn send(&self, request: &str) {
         self.inner.send(request);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,7 @@ impl Client {
     }
 }
 
+#[derive(Clone)]
 pub struct SendClient {
     inner: Arc<UnsafeClient>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ use std::ffi::{
 use std::time::Duration;
 use std::ops::Drop;
 
+use std::sync::Arc;
+
 pub fn set_log_file(path: &str) -> Result<i32, std::ffi::NulError> {
     let cpath = CString::new(path)?;
     unsafe {
@@ -28,37 +30,36 @@ pub fn set_log_verbosity_level(level : i32) {
     }
 }
 
-pub struct Client {
+struct UnsafeClient {
     client_ptr: *mut c_void
 }
 
-impl Client {
-    pub fn new() -> Self {
+impl UnsafeClient {
+    fn new() -> Self {
         unsafe {
-            Client {
+            UnsafeClient {
                 client_ptr: td_json_client_create()
             }
         }
     }
 
-    pub fn execute<'a>(&'a mut self, request: &str) -> Option<&'a str> {
+    /// UNSAFE: the returned slice is invalidated upon the next call to execute or receive
+    unsafe fn execute<'a>(&'a self, request: &str) -> Option<&'a str> {
         let crequest = CString::new(request).expect("null character in request string");
-        unsafe {
-            let answer = td_json_client_execute(
-                self.client_ptr,
-                crequest.as_ptr() as *const c_char
-            );
+        let answer = td_json_client_execute(
+            self.client_ptr,
+            crequest.as_ptr() as *const c_char
+        );
 
-            let answer = answer as *const c_char;
-            if answer == std::ptr::null() {
-                return None;
-            }
-            let answer = CStr::from_ptr(answer);
-            Some(answer.to_str().expect("tdlib sent invalid utf-8 string"))
+        let answer = answer as *const c_char;
+        if answer == std::ptr::null() {
+            return None;
         }
+        let answer = CStr::from_ptr(answer);
+        Some(answer.to_str().expect("tdlib sent invalid utf-8 string"))
     }
 
-    pub fn send(&self, request: &str) {
+    fn send(&self, request: &str) {
         let crequest = CString::new(request).expect("null character in request string");
         unsafe {
             td_json_client_send(
@@ -68,30 +69,105 @@ impl Client {
         }
     }
 
-    pub fn receive<'a>(&'a mut self, timeout: Duration) -> Option<&'a str> {
+    /// UNSAFE: the returned slice is invalidated upon the next call to execute or receive
+    unsafe fn receive<'a>(&'a self, timeout: Duration) -> Option<&'a str> {
         let timeout = timeout.as_secs() as f64;
 
+        let answer = td_json_client_receive(
+            self.client_ptr,
+            timeout
+        );
+
+        let answer = answer as *const c_char;
+        if answer == std::ptr::null() {
+            return None;
+        }
+        let answer = CStr::from_ptr(answer);
+
+        Some(answer.to_str().expect("tdlib sent invalid utf-8 string"))
+    }
+}
+
+impl Drop for UnsafeClient {
+    fn drop(&mut self) {
         unsafe {
-            let answer = td_json_client_receive(
-                self.client_ptr,
-                timeout
-            );
-
-            let answer = answer as *const c_char;
-            if answer == std::ptr::null() {
-                return None;
-            }
-            let answer = CStr::from_ptr(answer);
-
-            Some(answer.to_str().expect("tdlib sent invalid utf-8 string"))
+            td_json_client_destroy(self.client_ptr)
         }
     }
 }
 
-impl Drop for Client {
-    fn drop(&mut self) {
+pub struct Client {
+    inner: UnsafeClient,
+}
+
+impl Client {
+    pub fn new() -> Self {
+        Client {
+            inner: UnsafeClient::new(),
+        }
+    }
+
+    pub fn execute<'a>(&'a mut self, request: &str) -> Option<&'a str> {
+        // SAFE because we are taking self by mutable referene
         unsafe {
-            td_json_client_destroy(self.client_ptr)
+            self.inner.execute(request)
+        }
+    }
+
+    pub fn send(&self, request: &str) {
+        self.inner.send(request)
+    }
+
+    pub fn receive<'a>(&'a mut self, timeout: Duration) -> Option<&'a str> {
+        // SAFE because we are taking self by mutable referene
+        unsafe {
+            self.inner.receive(timeout)
+        }
+    }
+    pub fn split(self) -> (SendClient, ReceiveClient) {
+        let c = Arc::new(self.inner);
+        let s = SendClient {
+            inner: c.clone(),
+        };
+        let r = ReceiveClient {
+            inner: c.clone(),
+        };
+        (s, r)
+    }
+}
+
+pub struct SendClient {
+    inner: Arc<UnsafeClient>,
+}
+pub struct ReceiveClient {
+    inner: Arc<UnsafeClient>,
+}
+
+/// SAFE because the send method can be called by any threads
+unsafe impl Send for SendClient{}
+/// SAFE because the send method can be called by multiple threads at the same time
+unsafe impl Sync for SendClient{}
+
+impl SendClient {
+    pub fn execute<'a>(&'a mut self, request: &str) -> Option<&'a str> {
+        // SAFE because we are taking self by mutable referene
+        unsafe {
+            self.inner.execute(request)
+        }
+    }
+
+    pub fn send(&self, request: &str) {
+        self.inner.send(request);
+    }
+}
+
+/// SAFE because the send method can be called by any threads
+unsafe impl Send for ReceiveClient{}
+impl ReceiveClient {
+    pub fn receive<'a>(&'a mut self, timeout: Duration) -> Option<&'a str> {
+        // SAFE because we are taking self by mutable referene
+        unsafe {
+            self.inner.receive(timeout)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@ pub struct ReceiveClient {
     inner: Arc<UnsafeClient>,
 }
 
-/// SAFE because the send method can be called by any threads
+/// SAFE because the send method can be called by any thread
 unsafe impl Send for SendClient{}
 /// SAFE because the send method can be called by multiple threads at the same time
 unsafe impl Sync for SendClient{}
@@ -155,7 +155,7 @@ impl SendClient {
     }
 }
 
-/// SAFE because the send method can be called by any threads
+/// SAFE because the receive method can be called by any thread
 unsafe impl Send for ReceiveClient{}
 impl ReceiveClient {
     pub fn receive<'a>(&'a mut self, timeout: Duration) -> Option<&'a str> {


### PR DESCRIPTION
Hi,
I am working on a library based on this and tdlib-sys, and I found some issues both from a safety and ergonomics point of view.
Here you can see all my modifications, but if you prefer I can split this PR into multiple ones.
There are 3 main things here:
- Adding the logging functions recently exposed in tdlib-sys
- Fixing some errors in  handling strings in ffi 
- Adding the ability to split the client in a ClientSender and a ClientReceiver, so it is possible to use the library safely from multiple threads

Again, I am putting everything here so you can see the whole picture, but I can easily split it in 3, and you can of course accept only a part.

P.S.:  This currently does not compile because tdlib-sys 0.1.3 is not on crates.io, and so the logging functions are not defined. I tested it with a local version of the latest master.
There is an issue about it here -> https://github.com/mersinvald/tdjson-sys/issues/4